### PR TITLE
Attempting to load version from meta on install fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ BASE_DIR = path.abspath(path.dirname(__file__))
 
 # Navigate, import, and retrieve the version of the project.
 _imp = get_importer(path.join(BASE_DIR, 'src', 'saml'))
-meta = _imp.find_module('meta').load_module()
+meta = _imp.find_module('meta').load_module('meta')
 
 setup(
     name='saml',


### PR DESCRIPTION
When attempting to load version from the meta file in src/saml/meta.py it would fail because load_module is expecting the name of the module to load. Adding 'meta' to load_module fixes this.

++++

(env)samuel@samuel-Latitude-E6520:~/work/samltest$ pip install saml
Downloading/unpacking saml
  Downloading saml-0.3.3.tar.gz
  Running setup.py egg_info for package saml
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/home/samuel/work/samltest/env/build/saml/setup.py", line 11, in <module>
        meta = _imp.find_module('meta').load_module()
    TypeError: load_module() takes exactly 2 arguments (1 given)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/home/samuel/work/samltest/env/build/saml/setup.py", line 11, in <module>

```
meta = _imp.find_module('meta').load_module()
```

TypeError: load_module() takes exactly 2 arguments (1 given)

---

Cleaning up...
Command python setup.py egg_info failed with error code 1 in /home/samuel/work/samltest/env/build/saml
Storing complete log in /home/samuel/.pip/pip.log

++++
